### PR TITLE
Support for FlexVolume in volumes

### DIFF
--- a/trains-server-chart/templates/apiserver-deployment.yaml
+++ b/trains-server-chart/templates/apiserver-deployment.yaml
@@ -106,18 +106,18 @@ spec:
       {{- if .Values.use_secrets_flexvolume }}
         - name: apiserver-azurekeyvault
           flexVolume:
-          driver: "azure/kv"
-          secretRef:
-              name: {{ .Values.fv.secretRef }}
-          options:
-              usepodidentity: "{{ .Values.fv.usepodidentity }}"
-              resourcegroup: "{{ .Values.fv.resourcegroup }}"
-              keyvaultname: "{{ .Values.fv.keyvaultname }}"
-              keyvaultobjectnames: "{{ .Values.fv.keyvaultobjectnames }}"
-              keyvaultobjectaliases: "{{ .Values.fv.keyvaultobjectaliases }}"
-              keyvaultobjecttypes: "{{ .Values.fv.keyvaultobjecttypes }}"
-              subscriptionid: "{{ .Values.fv.subscriptionid }}"
-              tenantid: "{{ .Values.fv.tenantid }}"
+            driver: "azure/kv"
+            secretRef:
+                name: {{ .Values.fv.secretRef }}
+            options:
+                usepodidentity: "{{ .Values.fv.usepodidentity }}"
+                resourcegroup: "{{ .Values.fv.resourcegroup }}"
+                keyvaultname: "{{ .Values.fv.keyvaultname }}"
+                keyvaultobjectnames: "{{ .Values.fv.keyvaultobjectnames }}"
+                keyvaultobjectaliases: "{{ .Values.fv.keyvaultobjectaliases }}"
+                keyvaultobjecttypes: "{{ .Values.fv.keyvaultobjecttypes }}"
+                subscriptionid: "{{ .Values.fv.subscriptionid }}"
+                tenantid: "{{ .Values.fv.tenantid }}"
       {{- end }}
       {{- with .Values.apiserver.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/trains-server-chart/templates/apiserver-deployment.yaml
+++ b/trains-server-chart/templates/apiserver-deployment.yaml
@@ -82,21 +82,43 @@ spec:
           value: {{ .Values.apiserver.mongoServiceName }}
         - name: REDIS_SERVICE_HOST
           value: {{ .Values.apiserver.redisServiceName }}
+        {{- if .Values.use_secrets_flexvolume }}
+        - name: TRAINS_CONFIG_DIR
+          value: /opt/trains/config:/opt/trains/secrets
+        {{- else }}
+        - name: TRAINS_CONFIG_DIR
+          value: /opt/trains/config
+        {{- end }}
         args:
         - apiserver
-        volumeMounts:
-        - mountPath: /var/log/trains
-          name: apiserver-hostpath0
-        volumeMounts:
-          - mountPath: /opt/trains/config
-            name: apiserver-hostpath1
+        volumeMounts: 
+        {{- if .Values.use_secrets_flexvolume }}
+            - mountPath: /opt/trains/secrets
+              name: apiserver-azurekeyvault
+        {{- end }}
+        {{- with .Values.apiserver.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
       restartPolicy: Always
       nodeSelector:
         {{ .Values.trains.nodeSelector}}
       volumes:
-      - name: apiserver-hostpath0
-        hostPath:
-          path: /opt/trains/logs
-      - name: apiserver-hostpath1
-        hostPath:
-          path: /opt/trains/config
+      {{- if .Values.use_secrets_flexvolume }}
+        - name: apiserver-azurekeyvault
+          flexVolume:
+          driver: "azure/kv"
+          secretRef:
+              name: {{ .Values.fv.secretRef }}
+          options:
+              usepodidentity: "{{ .Values.fv.usepodidentity }}"
+              resourcegroup: "{{ .Values.fv.resourcegroup }}"
+              keyvaultname: "{{ .Values.fv.keyvaultname }}"
+              keyvaultobjectnames: "{{ .Values.fv.keyvaultobjectnames }}"
+              keyvaultobjectaliases: "{{ .Values.fv.keyvaultobjectaliases }}"
+              keyvaultobjecttypes: "{{ .Values.fv.keyvaultobjecttypes }}"
+              subscriptionid: "{{ .Values.fv.subscriptionid }}"
+              tenantid: "{{ .Values.fv.tenantid }}"
+      {{- end }}
+      {{- with .Values.apiserver.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/trains-server-chart/values.yaml
+++ b/trains-server-chart/values.yaml
@@ -11,6 +11,19 @@ apiserver:
   mongoServicePort: "27017"
   redisServiceName: redis
   redisServicePort: "6379"
+  configDir: /opt/trains/config
+  volumeMounts:
+    - mountPath: /var/log/trains
+      name: apiserver-hostpath0
+    - mountPath: /opt/trains/config
+      name: apiserver-hostpath1
+  volumes:
+    - name: apiserver-hostpath0
+      hostPath:
+        path: /opt/trains/logs
+    - name: apiserver-hostpath1
+      hostPath:
+        path: /opt/trains/config
 elasticsearch:
   esJavaOpts: "-Xms2g -Xmx2g"
 services:
@@ -29,3 +42,4 @@ services:
     name: elasticsearch-service
   redis:
     name: redis
+use_secrets_flexvolume: false


### PR DESCRIPTION
This PR is related to https://github.com/allegroai/trains-server-k8s/issues/1. 

It enables support for FlexVolume, which will allow developers to use Azure KeyVault to mount their secrets (and/or configuration). 