### PR TITLE
Added network policies and customizable node ports

### DIFF
--- a/clearml-server-cloud-ready/templates/network-policy-agentservices.yaml
+++ b/clearml-server-cloud-ready/templates/network-policy-agentservices.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "clearml.fullname" . }}-agentservices
+  labels:
+    {{- include "clearml.labels" . | nindent 4 }}
+spec:
+  egress:
+  - ports:
+    - port: 8008
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: {{ .Release.Name }}-apiserver
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}-agentservices
+  policyTypes:
+  - Egress

--- a/clearml-server-cloud-ready/templates/network-policy-apiserver.yaml
+++ b/clearml-server-cloud-ready/templates/network-policy-apiserver.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "clearml.fullname" . }}-apiserver
+  labels:
+    {{- include "clearml.labels" . | nindent 4 }}
+spec:
+  egress:
+  - ports:
+    - port: 6379
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app: redis
+  - ports:
+    - port: 9200
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+        {{- if .Values.elasticsearch.enabled }}
+          app: {{ .Release.Name }}-elastic-master
+        {{- else }}
+          {{ .Values.apiserver.networkPolicy.labels.elasticsearch.key }}: {{ .Values.apiserver.networkPolicy.labels.elasticsearch.value }}
+        {{- end }}
+  - ports:
+    - port: 27017
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/component: mongodb
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}-apiserver
+  policyTypes:
+  - Egress

--- a/clearml-server-cloud-ready/templates/network-policy-webserver.yaml
+++ b/clearml-server-cloud-ready/templates/network-policy-webserver.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "clearml.fullname" . }}-webserver
+  labels:
+    {{- include "clearml.labels" . | nindent 4 }}
+spec:
+  egress:
+  - ports:
+    - port: 8008
+      protocol: TCP
+    to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/instance: {{ .Release.Name }}-apiserver
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}-webserver
+  policyTypes:
+  - Egress

--- a/clearml-server-cloud-ready/templates/service-apiserver.yaml
+++ b/clearml-server-cloud-ready/templates/service-apiserver.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: {{ .Values.apiserver.service.port }}
       targetPort: {{ .Values.apiserver.service.port }}
-      nodePort: 30008
+      nodePort: {{ .Values.apiserver.service.nodePort }}
       protocol: TCP
   selector:
     {{- include "clearml.selectorLabelsApiServer" . | nindent 4 }}

--- a/clearml-server-cloud-ready/templates/service-fileserver.yaml
+++ b/clearml-server-cloud-ready/templates/service-fileserver.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: {{ .Values.fileserver.service.port }}
       targetPort: {{ .Values.fileserver.service.port }}
-      nodePort: 30081
+      nodePort: {{ .Values.fileserver.service.nodePort }}
       protocol: TCP
   selector:
     {{- include "clearml.selectorLabelsFileServer" . | nindent 4 }}

--- a/clearml-server-cloud-ready/templates/service-webserver.yaml
+++ b/clearml-server-cloud-ready/templates/service-webserver.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
     - port: {{ .Values.webserver.service.port }}
       targetPort: {{ .Values.webserver.service.port }}
-      nodePort: 30080
+      nodePort: {{ .Values.webserver.service.nodePort }}
       protocol: TCP
   selector:
     {{- include "clearml.selectorLabelsWebServer" . | nindent 4 }}


### PR DESCRIPTION
Due to certain specific of my k8s cluster deployment I kindly ask to introduce the following changes in the cloud-ready Helm chart:

1. Add network policies to allow the following egress connections:
- from agentservices to apiserver
- from apiserver to elasticsearch, mongodb and redis
- from webserver to apiserver

2. Allow customizable node ports because hard-coded ones are busy on my installation. Thus, I define node ports for each component in values.yaml and use these values in deployment templates.
